### PR TITLE
Add remote build and github-actions to test

### DIFF
--- a/.github/workflows/grapevne-container.yml
+++ b/.github/workflows/grapevne-container.yml
@@ -1,0 +1,60 @@
+name: Check GRAPEVNE workflow (remote container build)
+
+on:
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
+        required: false
+        default: false
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "workflows/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "workflows/**"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workflows/Dengue/sources/build_remote
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Miniforge
+        run: |
+          wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+          bash Miniforge3.sh -b -p "${HOME}/conda"
+      - name: Install Snakemake
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pulp==2.7.0 snakemake==7.32
+      - name: Build GRAPEVNE container
+        run: |
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          source "${HOME}/conda/etc/profile.d/mamba.sh"
+          mamba activate
+          ./build_container.sh
+      - name: tmate debugging
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      - name: Launch GRAPEVNE container
+        run: |
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          source "${HOME}/conda/etc/profile.d/mamba.sh"
+          mamba activate
+          ./launch_container.sh

--- a/.github/workflows/grapevne-remote.yml
+++ b/.github/workflows/grapevne-remote.yml
@@ -1,0 +1,45 @@
+name: Check GRAPEVNE workflow (remote build)
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "workflows/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "workflows/**"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workflows/Dengue/sources/build_remote
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Miniforge
+        run: |
+          wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+          bash Miniforge3.sh -b -p "${HOME}/conda"
+      - name: Install Snakemake
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pulp==2.7.0 snakemake==7.32
+      - name: Run GRAPEVNE workflow (local build)
+        run: |
+          source "${HOME}/conda/etc/profile.d/conda.sh"
+          source "${HOME}/conda/etc/profile.d/mamba.sh"
+          mamba activate
+          ./run.sh

--- a/workflows/Dengue/sources/AcquireData/workflow/envs/ncbi_datasets_env.yaml
+++ b/workflows/Dengue/sources/AcquireData/workflow/envs/ncbi_datasets_env.yaml
@@ -4,3 +4,4 @@ channels:
 - conda-forge
 dependencies:
 - ncbi-datasets-cli
+- unzip

--- a/workflows/Dengue/sources/build_remote/Dockerfile
+++ b/workflows/Dengue/sources/build_remote/Dockerfile
@@ -1,0 +1,20 @@
+FROM condaforge/mambaforge:23.3.1-1 as conda
+
+# Install snakemake
+RUN mamba install -y snakemake-minimal==7.32 -c bioconda
+
+# Pass UID to container (ensures appropriate permissions for created files/directories)
+ARG HOST_UID
+RUN useradd --uid ${HOST_UID} --create-home user
+USER user
+
+# Copy workflow files to container
+COPY --chown=user . /home/user/
+WORKDIR /home/user/
+
+# Set-up the workflow conda environments
+ENV TERM=xterm-color
+RUN snakemake --conda-create-envs-only --use-conda --cores 1 plotexportsandimports_target
+
+# Run the workflow script
+CMD ["bash", "-i", "-c", "./run.sh"]

--- a/workflows/Dengue/sources/build_remote/build_container.sh
+++ b/workflows/Dengue/sources/build_remote/build_container.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Halt upon error
+set -eoux pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Provide a name for the container here
+NAME="grapevne-build"
+TARGET_RULES="plotexportsandimports_target"
+
+# Construct image
+docker build \
+    --platform linux/amd64 \
+    --no-cache \
+    --build-arg HOST_UID=$(id -u) \
+    --build-arg TARGET_RULES="${TARGET_RULES}" \
+    -t "${NAME}" \
+    "${SCRIPT_DIR}"

--- a/workflows/Dengue/sources/build_remote/config/config.yaml
+++ b/workflows/Dengue/sources/build_remote/config/config.yaml
@@ -1,0 +1,263 @@
+input_namespace: null
+output_namespace: plotexportsandimports
+acquiredata:
+  name: AcquireData
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/sources/AcquireData/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: null
+    output_namespace: acquiredata
+    params:
+      Sequence: virus genome taxon "Dengue Virus"
+      Data format: virus-genome
+      Date: 01/01/2010
+      Command line arguments: []
+processgenbankdata:
+  name: ProcessGenbankData
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/ProcessGenbankData/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: acquiredata
+    output_namespace: processgenbankdata
+    params:
+      Start date: '2000-01-01T00:00:00.000Z'
+      End date: '2023-12-24T00:00:00.000Z'
+      Host: Homo sapiens
+processdenguedata:
+  name: ProcessDengueData
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/ProcessDengueData/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: processgenbankdata
+    output_namespace: processdenguedata
+sequencealignment:
+  name: SequenceAlignment
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/SequenceAlignment/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: processdenguedata
+    output_namespace: sequencealignment
+splitgenomeandqc:
+  name: SplitGenomeAndQC
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/SplitGenomeAndQC/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: sequencealignment
+    output_namespace: splitgenomeandqc
+    params:
+      WG Threshold: 0.29
+      EG Threshold: 0.29
+      Serotypes:
+      - Dengue_1
+      - Dengue_2
+      - Dengue_3
+      - Dengue_4
+subsample_denv:
+  name: Subsample_DENV
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/Subsample_DENV/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace:
+      metadata: processdenguedata
+      fasta: splitgenomeandqc
+    output_namespace: subsample_denv
+    params:
+      Number of sequences (local): 10
+      Number of sequences (background): 100
+      Time Interval: Year
+      Sampling Method: Even
+      Serotypes:
+      - Serotype: denv1
+        Filename: Dengue_1
+      - Serotype: denv2
+        Filename: Dengue_2
+      - Serotype: denv3
+        Filename: Dengue_3
+      - Serotype: denv4
+        Filename: Dengue_4
+reformatting:
+  name: Reformatting
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/Reformatting/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: subsample_denv
+    output_namespace: reformatting
+treebuilding:
+  name: TreeBuilding
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/TreeBuilding/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: reformatting
+    output_namespace: treebuilding
+    params:
+      Model: GTR+F+I
+      Command line arguments: -nt AUTO
+treetime:
+  name: TreeTime
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/TreeTime/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace:
+      fasta: treebuilding
+      metadata: reformatting
+    output_namespace: treetime
+    params:
+      Clock filter IQD: 3
+mutations:
+  name: Mutations
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/Mutations/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace:
+      fasta: treetime
+      metadata: reformatting
+    output_namespace: mutations
+translation:
+  name: Translation
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/Translation/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace:
+      treetime: treetime
+      mutations: mutations
+    output_namespace: translation
+mugration:
+  name: Mugration
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/Mugration/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace:
+      treetime: treetime
+      subsample: reformatting
+    output_namespace: mugration
+export:
+  name: Export
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/Export/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace:
+      treetime: treetime
+      translation: translation
+      subsample: reformatting
+      mutations: mutations
+      mugrations: mugration
+    output_namespace: export
+extractphylotree:
+  name: ExtractPhyloTree
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/ExtractPhyloTree/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: export
+    output_namespace: extractphylotree
+treebreakdown:
+  name: TreeBreakdown
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/TreeBreakdown/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: extractphylotree
+    output_namespace: treebreakdown
+plotexportsandimports:
+  name: PlotExportsAndImports
+  type: module
+  snakefile:
+    function: github
+    args:
+    - rhysinward/dengue_pipeline
+    kwargs:
+      path: workflows/Dengue/modules/PlotExportsAndImports/workflow/Snakefile
+      branch: main
+  config:
+    input_namespace: treebreakdown
+    output_namespace: plotexportsandimports
+    params:
+      Country: Vietnam

--- a/workflows/Dengue/sources/build_remote/launch_container.sh
+++ b/workflows/Dengue/sources/build_remote/launch_container.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Halt upon error
+set -eoux pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Provide a name for the container here
+NAME="grapevne-build"
+
+# Ensure mounted directories exist before mount (consistent permissions in the container)
+mkdir -p "${SCRIPT_DIR}"/results
+mkdir -p "${SCRIPT_DIR}"/benchmark
+mkdir -p "${SCRIPT_DIR}"/logs
+
+# Launch image
+docker run \
+    --platform linux/amd64 \
+    -v "${SCRIPT_DIR}"/results:/home/user/results \
+    -v "${SCRIPT_DIR}"/benchmark:/home/user/benchmark \
+    -v "${SCRIPT_DIR}"/benchmark:/home/user/logs \
+    "${NAME}"

--- a/workflows/Dengue/sources/build_remote/run.sh
+++ b/workflows/Dengue/sources/build_remote/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+snakemake --snakefile workflow/Snakefile --cores 1 --use-conda plotexportsandimports_target

--- a/workflows/Dengue/sources/build_remote/workflow/Snakefile
+++ b/workflows/Dengue/sources/build_remote/workflow/Snakefile
@@ -1,0 +1,177 @@
+configfile: "config/config.yaml"
+
+module acquiredata:
+    snakefile:
+        eval(
+            f'{config["acquiredata"]["snakefile"]["function"]}'
+            '(*config["acquiredata"]["snakefile"]["args"],'
+            '**config["acquiredata"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["acquiredata"]["config"]
+use rule * from acquiredata as acquiredata_*
+
+module processgenbankdata:
+    snakefile:
+        eval(
+            f'{config["processgenbankdata"]["snakefile"]["function"]}'
+            '(*config["processgenbankdata"]["snakefile"]["args"],'
+            '**config["processgenbankdata"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["processgenbankdata"]["config"]
+use rule * from processgenbankdata as processgenbankdata_*
+
+module processdenguedata:
+    snakefile:
+        eval(
+            f'{config["processdenguedata"]["snakefile"]["function"]}'
+            '(*config["processdenguedata"]["snakefile"]["args"],'
+            '**config["processdenguedata"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["processdenguedata"]["config"]
+use rule * from processdenguedata as processdenguedata_*
+
+module sequencealignment:
+    snakefile:
+        eval(
+            f'{config["sequencealignment"]["snakefile"]["function"]}'
+            '(*config["sequencealignment"]["snakefile"]["args"],'
+            '**config["sequencealignment"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["sequencealignment"]["config"]
+use rule * from sequencealignment as sequencealignment_*
+
+module splitgenomeandqc:
+    snakefile:
+        eval(
+            f'{config["splitgenomeandqc"]["snakefile"]["function"]}'
+            '(*config["splitgenomeandqc"]["snakefile"]["args"],'
+            '**config["splitgenomeandqc"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["splitgenomeandqc"]["config"]
+use rule * from splitgenomeandqc as splitgenomeandqc_*
+
+module subsample_denv:
+    snakefile:
+        eval(
+            f'{config["subsample_denv"]["snakefile"]["function"]}'
+            '(*config["subsample_denv"]["snakefile"]["args"],'
+            '**config["subsample_denv"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["subsample_denv"]["config"]
+use rule * from subsample_denv as subsample_denv_*
+
+module reformatting:
+    snakefile:
+        eval(
+            f'{config["reformatting"]["snakefile"]["function"]}'
+            '(*config["reformatting"]["snakefile"]["args"],'
+            '**config["reformatting"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["reformatting"]["config"]
+use rule * from reformatting as reformatting_*
+
+module treebuilding:
+    snakefile:
+        eval(
+            f'{config["treebuilding"]["snakefile"]["function"]}'
+            '(*config["treebuilding"]["snakefile"]["args"],'
+            '**config["treebuilding"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["treebuilding"]["config"]
+use rule * from treebuilding as treebuilding_*
+
+module treetime:
+    snakefile:
+        eval(
+            f'{config["treetime"]["snakefile"]["function"]}'
+            '(*config["treetime"]["snakefile"]["args"],'
+            '**config["treetime"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["treetime"]["config"]
+use rule * from treetime as treetime_*
+
+module mutations:
+    snakefile:
+        eval(
+            f'{config["mutations"]["snakefile"]["function"]}'
+            '(*config["mutations"]["snakefile"]["args"],'
+            '**config["mutations"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["mutations"]["config"]
+use rule * from mutations as mutations_*
+
+module translation:
+    snakefile:
+        eval(
+            f'{config["translation"]["snakefile"]["function"]}'
+            '(*config["translation"]["snakefile"]["args"],'
+            '**config["translation"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["translation"]["config"]
+use rule * from translation as translation_*
+
+module mugration:
+    snakefile:
+        eval(
+            f'{config["mugration"]["snakefile"]["function"]}'
+            '(*config["mugration"]["snakefile"]["args"],'
+            '**config["mugration"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["mugration"]["config"]
+use rule * from mugration as mugration_*
+
+module export:
+    snakefile:
+        eval(
+            f'{config["export"]["snakefile"]["function"]}'
+            '(*config["export"]["snakefile"]["args"],'
+            '**config["export"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["export"]["config"]
+use rule * from export as export_*
+
+module extractphylotree:
+    snakefile:
+        eval(
+            f'{config["extractphylotree"]["snakefile"]["function"]}'
+            '(*config["extractphylotree"]["snakefile"]["args"],'
+            '**config["extractphylotree"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["extractphylotree"]["config"]
+use rule * from extractphylotree as extractphylotree_*
+
+module treebreakdown:
+    snakefile:
+        eval(
+            f'{config["treebreakdown"]["snakefile"]["function"]}'
+            '(*config["treebreakdown"]["snakefile"]["args"],'
+            '**config["treebreakdown"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["treebreakdown"]["config"]
+use rule * from treebreakdown as treebreakdown_*
+
+module plotexportsandimports:
+    snakefile:
+        eval(
+            f'{config["plotexportsandimports"]["snakefile"]["function"]}'
+            '(*config["plotexportsandimports"]["snakefile"]["args"],'
+            '**config["plotexportsandimports"]["snakefile"]["kwargs"])'
+        )
+    config:
+        config["plotexportsandimports"]["config"]
+use rule * from plotexportsandimports as plotexportsandimports_*


### PR DESCRIPTION
Added `build_remote` module, which incorporates the dengue pipeline and can be used directly in GRAPEVNE.

Also added github action that build and test the workflow using the remote build, and also using the remote build from a container - _note that these may not pass during this PR since module files were updated as part of this PR, so will be out-of-sync until the PR is merged_

Resolves #6 